### PR TITLE
doc: update ug_radio_fem.rst user guide

### DIFF
--- a/doc/nrf/ug_radio_fem.rst
+++ b/doc/nrf/ug_radio_fem.rst
@@ -85,16 +85,14 @@ To use nRF21540 in GPIO mode, complete the following steps:
 
    The state of the remaining control pins should be set in other ways and according to `nRF21540 Product Specification`_.
 
-#. Additionally on nRF53 devices, the same devicetree node must be applied to the network core:
+#. On nRF53 devices, you must also apply the same devicetree node mentioned in step 1 to the network core.
+   To do so, apply the overlay to the correct network core child image by creating an overlay file named :file:`child_image/*childImageName*.overlay` in your application directory, for example :file:`child_image/multiprotocol_rpmsg.overlay`.
 
-   The overlay can be applied to network core child images by creating an overlay file named
-   :file:`child_image/*childImageName*.overlay` in your application directory, for example
-   :file:`child_image/multiprotocol_rpmsg.overlay`.
-   The *childImageName* can take the following values:
+   The ``*childImageName*`` string must be one of the following values:
 
-   *  ``multiprotocol_rpmsg`` for multiprotocol applications with support for 802.15.4 and Bluetooth
-   *  ``802154_rpmsg`` for applications with support for 802.15.4, but without support for Bluetooth
-   *  ``hci_rpmsg`` for application with support for Bluetooth, but without support for 802.15.4
+   *  ``multiprotocol_rpmsg`` for multiprotocol applications having support for both 802.15.4 and Bluetooth.
+   *  ``802154_rpmsg`` for applications having support for 802.15.4, but not for Bluetooth.
+   *  ``hci_rpmsg`` for application having support for Bluetooth, but not for 802.15.4.
 
 Optional properties
 ===================
@@ -128,7 +126,8 @@ Adding support for SKY66112-11
 ******************************
 
 SKY66112-11 is one of many FEM devices that support the 2-pin PA/LNA interface.
-Currently, only the nRF52 Series devices support this interface. nRF53 Series devices are not supported.
+Currently, only the nRF52 Series devices support this interface.
+nRF53 Series devices are not supported.
 
 .. note::
   In the naming convention used in the API of the MPSL library, the functionalities designated as ``PA`` and ``LNA`` apply to the ``ctx-gpios`` and ``crx-gpios`` pins listed below, respectively.
@@ -210,7 +209,7 @@ Two nRF21540 boards are available, showcasing the possibilities of the nRF21540 
 * :ref:`nRF21540 DK <nrf21540dk_nrf52840>`
 * nRF21540 EK, described in sections below
 
-The front-end module feature is supported on the nRF52 and nRF53 Series.
+The front-end module feature is supported on the nRF52 and nRF53 Series devices.
 
 .. _ug_radio_fem_nrf21540_ek:
 


### PR DESCRIPTION
The user guide was brought up-to-date:
- nRF53 Series devices are now supported

Signed-off-by: Rafał Kuźnia <rafal.kuznia@nordicsemi.no>